### PR TITLE
Implement `Array::erase(int)`

### DIFF
--- a/data_structures/array.cpp
+++ b/data_structures/array.cpp
@@ -79,7 +79,7 @@ void Array::pop(int indice) {
 
 void Array::erase(int value) {
   int i = 0;
-  for (chain* iterator = index(0); iterator != NULL; iterator = iterator->next)
+  for (chain* iterator = head; iterator != NULL && length > 1; iterator = iterator->next)
   {
     if (iterator->data == value)
     {

--- a/data_structures/array.cpp
+++ b/data_structures/array.cpp
@@ -11,6 +11,7 @@ class Array {
     // Methods
     void push_back(int);
     void pop(int);
+    void erase(int);
     int* convert();
     chain* index(int);
 
@@ -74,6 +75,19 @@ void Array::pop(int indice) {
     head = iterator->next;
   }
   delete iterator;
+}
+
+void Array::erase(int value) {
+  int i = 0;
+  for (chain* iterator = index(0); iterator != NULL; iterator = iterator->next)
+  {
+    if (iterator->data == value)
+    {
+      pop(i);
+      i--;
+    }
+    i++;
+  }
 }
 
 int* Array::convert() {


### PR DESCRIPTION
Erases all instances of an `int` in the linked list.
Also loving how you're calling this an array, despite that it's just a more accessible linked list.
Then again, I guess that is what arrays are anyways.